### PR TITLE
Adding READI support for FORCES

### DIFF
--- a/beamformer.meta
+++ b/beamformer.meta
@@ -168,6 +168,14 @@
 @Library        @Struct FilterParameters
 @MATLAB(Filter) @Struct FilterParameters
 
+@Struct ReadiParameters
+{
+	[readi_group_count  U32]
+	[readi_group        U32]
+}
+@Library 		@Struct ReadiParameters
+@MATLAB(readi) 	@Struct ReadiParameters
+
 @Struct ParametersHead
 {
 	[das_voxel_transform          M4             ]
@@ -203,6 +211,7 @@
 {
 	[contrast_mode       ContrastMode      ]
 	[emission_parameters EmissionParameters]
+	[readi_parameters    ReadiParameters   ]
 }
 
 @Struct Parameters
@@ -439,6 +448,9 @@
 			[SingleFocus                B32]
 			[FocusDepth                 F32]
 			[TransmitAngle              F32]
+
+			[ReadiGroupCount            U32]
+			[ReadiGroup                 U32]
 		}
 
 		@PushConstants
@@ -455,6 +467,7 @@
 			[output_size_z     U32]
 			[cycle_t           U32]
 			[channel_offset    S32]
+			[hadamard_buffer   U64]
 		}
 	}
 

--- a/beamformer.meta
+++ b/beamformer.meta
@@ -1,11 +1,12 @@
-@Constant(16)   ChunkChannelCount
-@Constant(4)    FilterSlots
-@Constant(4096) MaxBacklogFrames
-@Constant(256)  MaxChannelCount
-@Constant(256)  MaxEmissionsCount
-@Constant(16)   MaxComputeShaderStages
-@Constant(16)   MaxParameterBlocks
-@Constant(3)    MaxRawDataFramesInFlight
+@Constant(16)     ChunkChannelCount
+@Constant(4)      FilterSlots
+@Constant(4096)   MaxBacklogFrames
+@Constant(256)    MaxChannelCount
+@Constant(256)    MaxEmissionsCount
+@Constant(16)     MaxComputeShaderStages
+@Constant(16)     MaxParameterBlocks
+@Constant(3)      MaxRawDataFramesInFlight
+@Constant(65536)  MaxHadamardElements
 
 @Enumeration ShaderResourceKind
 {
@@ -168,14 +169,6 @@
 @Library        @Struct FilterParameters
 @MATLAB(Filter) @Struct FilterParameters
 
-@Struct ReadiParameters
-{
-	[readi_group_count  U32]
-	[readi_group        U32]
-}
-@Library 		@Struct ReadiParameters
-@MATLAB(readi) 	@Struct ReadiParameters
-
 @Struct ParametersHead
 {
 	[das_voxel_transform          M4             ]
@@ -211,7 +204,8 @@
 {
 	[contrast_mode       ContrastMode      ]
 	[emission_parameters EmissionParameters]
-	[readi_parameters    ReadiParameters   ]
+	[readi_group_count   U32]
+	[readi_group         U32]
 }
 
 @Struct Parameters
@@ -278,6 +272,7 @@
 	[focal_vectors                 V2  MaxChannelCount]
 	[sparse_elements               S16 MaxChannelCount]
 	[transmit_receive_orientations U16 MaxChannelCount]
+	[hadamard_matrix               F16 MaxHadamardElements]
 }
 
 @Emit
@@ -413,6 +408,7 @@
 	@Shader(das.glsl) DAS
 	{
 		@Constant    MaxChannelCount
+		@Constant    MaxHadamardElements
 
 		@Enumeration AcquisitionKind
 		@Enumeration InterpolationMode
@@ -450,7 +446,6 @@
 			[TransmitAngle              F32]
 
 			[ReadiGroupCount            U32]
-			[ReadiGroup                 U32]
 		}
 
 		@PushConstants
@@ -467,7 +462,7 @@
 			[output_size_z     U32]
 			[cycle_t           U32]
 			[channel_offset    S32]
-			[hadamard_buffer   U64]
+			[readi_group       U32]
 		}
 	}
 

--- a/beamformer_core.c
+++ b/beamformer_core.c
@@ -271,12 +271,17 @@ das_valid_points(iv3 points)
 }
 
 function void
-beamformer_update_hadamard(BeamformerComputePlan *cp, i32 order, b32 row_major, Arena arena)
+beamformer_update_hadamard(BeamformerComputePlan *cp, i32 order, b32 row_major, Arena arena, b32 readi_matrix)
 {
 	f16 *hadamard = make_hadamard_transpose(&arena, order, row_major);
 	if (hadamard) {
-		u64 offset = offsetof(BeamformerComputeArrayParameters, Hadamard);
-		u64 size   = sizeof(*((BeamformerComputeArrayParameters *)0)->Hadamard) * order * order;
+		u64 offset = readi_matrix ? 
+					 offsetof(BeamformerComputeArrayParameters, ReadiDasHadamard) : 
+					 offsetof(BeamformerComputeArrayParameters, Hadamard);
+		u64 size   = readi_matrix ? 
+					 sizeof(*((BeamformerComputeArrayParameters *)0)->ReadiDasHadamard) : 
+					 sizeof(*((BeamformerComputeArrayParameters *)0)->Hadamard);
+		size *= order * order;
 		vk_buffer_range_upload(&cp->array_parameters, hadamard, offset, size, 0);
 		cp->hadamard_order = order;
 	}
@@ -738,6 +743,8 @@ plan_compute_pipeline(BeamformerComputePlan *cp, BeamformerParameterBlock *pb, A
 				db->TransmitAngle         = pb->parameters.focal_vector.E[0];
 				db->FocusDepth            = pb->parameters.focal_vector.E[1];
 				db->TransmitReceiveOrientation = pb->parameters.transmit_receive_orientation;
+				db->ReadiGroupCount         = pb->parameters.readi_parameters.readi_group_count;
+				db->ReadiGroup            = pb->parameters.readi_parameters.readi_group;
 
 				// NOTE(rnp): old gcc will miscompile an assignment
 				memory_copy(cp->xdc_transform.E, pb->parameters.xdc_transform.E, sizeof(cp->xdc_transform));
@@ -1060,7 +1067,10 @@ beamformer_commit_parameter_block(BeamformerCtx *ctx, BeamformerComputePlan *cp,
 			if (pb->parameters.decode_mode != BeamformerDecodeMode_None &&
 			    cp->hadamard_order != (i32)cp->acquisition_count)
 			{
-				beamformer_update_hadamard(cp, (i32)cp->acquisition_count, vk_gpu_info()->cooperative_matrix, arena);
+				beamformer_update_hadamard(cp, (i32)cp->acquisition_count, vk_gpu_info()->cooperative_matrix, arena, false);
+
+				if (pb->parameters.readi_parameters.readi_group_count > 1)
+					beamformer_update_hadamard(cp, (i32)pb->parameters.readi_parameters.readi_group_count, false, arena, true);
 			}
 		}break;
 
@@ -1239,6 +1249,7 @@ do_compute_shader(BeamformerCtx *ctx, VulkanHandle cmd, BeamformerComputePlan *c
 			.cycle_t           = das_cycle_t++,
 			.channel_offset    = channel_offset,
 			.array_parameters  = cp->array_parameters.gpu_pointer + offsetof(BeamformerComputeArrayParameters, FocalVectors),
+			.hadamard_buffer   = cp->array_parameters.gpu_pointer + offsetof(BeamformerComputeArrayParameters, ReadiDasHadamard),
 		};
 		memory_copy(pc.voxel_transform.E, cp->das_voxel_transform.E, sizeof(pc.voxel_transform));
 		memory_copy(pc.xdc_transform.E,   cp->xdc_transform.E,       sizeof(pc.xdc_transform));

--- a/beamformer_core.c
+++ b/beamformer_core.c
@@ -271,19 +271,19 @@ das_valid_points(iv3 points)
 }
 
 function void
-beamformer_update_hadamard(BeamformerComputePlan *cp, i32 order, b32 row_major, Arena arena, b32 readi_matrix)
+beamformer_update_hadamard(BeamformerComputePlan *cp, i32 order, b32 row_major, Arena arena, b32 das_matrix)
 {
 	f16 *hadamard = make_hadamard_transpose(&arena, order, row_major);
 	if (hadamard) {
-		u64 offset = readi_matrix ? 
-					 offsetof(BeamformerComputeArrayParameters, ReadiDasHadamard) : 
-					 offsetof(BeamformerComputeArrayParameters, Hadamard);
-		u64 size   = readi_matrix ? 
-					 sizeof(*((BeamformerComputeArrayParameters *)0)->ReadiDasHadamard) : 
-					 sizeof(*((BeamformerComputeArrayParameters *)0)->Hadamard);
+		u64 offset = das_matrix ? 
+					 offsetof(BeamformerComputeArrayParameters, DasHadamard) : 
+					 offsetof(BeamformerComputeArrayParameters, DecodeHadamard);
+		u64 size   = das_matrix ? 
+					 sizeof(*((BeamformerComputeArrayParameters *)0)->DasHadamard) : 
+					 sizeof(*((BeamformerComputeArrayParameters *)0)->DecodeHadamard);
 		size *= order * order;
 		vk_buffer_range_upload(&cp->array_parameters, hadamard, offset, size, 0);
-		cp->hadamard_order = order;
+		if(!das_matrix) cp->hadamard_order = order;
 	}
 }
 
@@ -743,8 +743,9 @@ plan_compute_pipeline(BeamformerComputePlan *cp, BeamformerParameterBlock *pb, A
 				db->TransmitAngle         = pb->parameters.focal_vector.E[0];
 				db->FocusDepth            = pb->parameters.focal_vector.E[1];
 				db->TransmitReceiveOrientation = pb->parameters.transmit_receive_orientation;
-				db->ReadiGroupCount         = pb->parameters.readi_parameters.readi_group_count;
-				db->ReadiGroup            = pb->parameters.readi_parameters.readi_group;
+				db->ReadiGroupCount         = pb->parameters.readi_group_count;
+
+				cp->readi_group = pb->parameters.readi_group;
 
 				// NOTE(rnp): old gcc will miscompile an assignment
 				memory_copy(cp->xdc_transform.E, pb->parameters.xdc_transform.E, sizeof(cp->xdc_transform));
@@ -1069,8 +1070,8 @@ beamformer_commit_parameter_block(BeamformerCtx *ctx, BeamformerComputePlan *cp,
 			{
 				beamformer_update_hadamard(cp, (i32)cp->acquisition_count, vk_gpu_info()->cooperative_matrix, arena, false);
 
-				if (pb->parameters.readi_parameters.readi_group_count > 1)
-					beamformer_update_hadamard(cp, (i32)pb->parameters.readi_parameters.readi_group_count, false, arena, true);
+				if (pb->parameters.readi_group_count > 1)
+					beamformer_update_hadamard(cp, (i32)pb->parameters.readi_group_count, false, arena, true);
 			}
 		}break;
 
@@ -1141,7 +1142,7 @@ do_compute_shader(BeamformerCtx *ctx, VulkanHandle cmd, BeamformerComputePlan *c
 
 	case BeamformerShaderKind_Decode:{
 		BeamformerDecodePushConstants pc = {
-			.hadamard_buffer = cp->array_parameters.gpu_pointer + offsetof(BeamformerComputeArrayParameters, Hadamard),
+			.hadamard_buffer = cp->array_parameters.gpu_pointer + offsetof(BeamformerComputeArrayParameters, DecodeHadamard),
 			.rf_buffer       = pp_input_pointer,
 		};
 
@@ -1248,8 +1249,8 @@ do_compute_shader(BeamformerCtx *ctx, VulkanHandle cmd, BeamformerComputePlan *c
 			.output_size_z     = cp->output_points.z,
 			.cycle_t           = das_cycle_t++,
 			.channel_offset    = channel_offset,
+			.readi_group       = cp->readi_group,
 			.array_parameters  = cp->array_parameters.gpu_pointer + offsetof(BeamformerComputeArrayParameters, FocalVectors),
-			.hadamard_buffer   = cp->array_parameters.gpu_pointer + offsetof(BeamformerComputeArrayParameters, ReadiDasHadamard),
 		};
 		memory_copy(pc.voxel_transform.E, cp->das_voxel_transform.E, sizeof(pc.voxel_transform));
 		memory_copy(pc.xdc_transform.E,   cp->xdc_transform.E,       sizeof(pc.xdc_transform));

--- a/beamformer_core.c
+++ b/beamformer_core.c
@@ -1433,15 +1433,29 @@ complete_queue(BeamformerCtx *ctx, BeamformWorkQueue *q, Arena *arena)
 			BeamformerExportContext *ec = &work->export_context;
 			switch (ec->kind) {
 			case BeamformerExportKind_BeamformedData:{
-				BeamformerFrame *f = ctx->latest_frame;
-				if (f) {
-					u64 frame_size = beamformer_frame_byte_size(f->points, f->data_kind);
-					assert((frame_size & 63) == 0);
-					if (frame_size <= ec->size) {
-						vk_host_wait_timeline(VulkanTimeline_Compute, f->timeline_valid_value, -1ULL);
-						vk_buffer_range_download(beamformer_shared_memory_scratch_arena(sm, ctx->shared_memory_size).beg,
-						                         ctx->compute_context.backlog.buffer, f->buffer_offset,
-						                         frame_size, 1);
+				BeamformerFrameBacklog *bl = &ctx->compute_context.backlog;
+				u32 frame_counter = bl->counter;
+
+				/* NOTE(tkh): Assume a count of 0 means get the last frame. */
+				u32 req_count = ec->count ? ec->count : 1u; 
+				if (frame_counter == 0) break;
+				else if (req_count > frame_counter) req_count = frame_counter;
+
+				u32 frame_idx = frame_counter - req_count;
+				u8 *sm_output = beamformer_shared_memory_scratch_arena(sm, ctx->shared_memory_size).beg;
+				u64 exported_size = 0;
+				for(u32 export_count = 0; export_count < req_count; export_count++, frame_idx++) {
+					BeamformerFrame *f = bl->frames + frame_idx % countof(bl->frames);
+					if (f) {
+						u64 frame_size = beamformer_frame_byte_size(f->points, f->data_kind);
+						assert((frame_size & 63) == 0);
+						/* NOTE(tkh) we don't want to assume that all req_count frames are the same size,
+						so we either need to count the total size of all requested frames first or just fill up as much as possible. */
+						if (exported_size + frame_size <= ec->size) {
+							vk_host_wait_timeline(VulkanTimeline_Compute, f->timeline_valid_value, -1ULL);
+							vk_buffer_range_download(sm_output + exported_size, bl->buffer, f->buffer_offset, frame_size, 1);
+							exported_size += frame_size;
+						}
 					}
 				}
 			}break;

--- a/beamformer_internal.h
+++ b/beamformer_internal.h
@@ -270,6 +270,7 @@ typedef struct {
 	X(FocalVectors,                v2,  BeamformerMaxChannelCount) \
 	X(SparseElements,              i16, BeamformerMaxChannelCount) \
 	X(TransmitReceiveOrientations, u16, BeamformerMaxChannelCount) \
+	X(ReadiDasHadamard,            f16, BeamformerMaxChannelCount * BeamformerMaxChannelCount) \
 
 typedef enum {
 	#define X(k, ...) BeamformerComputeArrayParameterKind_##k,

--- a/beamformer_internal.h
+++ b/beamformer_internal.h
@@ -266,11 +266,11 @@ typedef struct {
 
 // X(kind, format, elements)
 #define BEAMFORMER_COMPUTE_ARRAY_PARAMETERS_LIST \
-	X(Hadamard,                    f16, BeamformerMaxChannelCount * BeamformerMaxChannelCount) \
+	X(DecodeHadamard,              f16, BeamformerMaxChannelCount * BeamformerMaxChannelCount) \
 	X(FocalVectors,                v2,  BeamformerMaxChannelCount) \
 	X(SparseElements,              i16, BeamformerMaxChannelCount) \
 	X(TransmitReceiveOrientations, u16, BeamformerMaxChannelCount) \
-	X(ReadiDasHadamard,            f16, BeamformerMaxChannelCount * BeamformerMaxChannelCount) \
+	X(DasHadamard,                 f16, BeamformerMaxChannelCount * BeamformerMaxChannelCount) \
 
 typedef enum {
 	#define X(k, ...) BeamformerComputeArrayParameterKind_##k,
@@ -325,6 +325,8 @@ struct BeamformerComputePlan {
 	// TODO(rnp): specialization constants
 	v2  xdc_element_pitch;
 	m4  xdc_transform;
+
+	u32  readi_group;
 
 	GPUBuffer array_parameters;
 

--- a/beamformer_shared_memory.c
+++ b/beamformer_shared_memory.c
@@ -23,7 +23,8 @@ typedef enum {
 
 typedef struct {
 	BeamformerExportKind kind;
-	u32 size;
+	u32 size; /* Total expected size of the exported data */
+	u32 count; /* Number of items to export */
 } BeamformerExportContext;
 
 #define BEAMFORMER_SHARED_MEMORY_LOCKS \

--- a/beamformer_shared_memory.c
+++ b/beamformer_shared_memory.c
@@ -23,8 +23,8 @@ typedef enum {
 
 typedef struct {
 	BeamformerExportKind kind;
-	u32 size; /* Total expected size of the exported data */
 	u32 count; /* Number of items to export */
+	u64 size; /* Total expected size of the exported data */
 } BeamformerExportContext;
 
 #define BEAMFORMER_SHARED_MEMORY_LOCKS \

--- a/generated/beamformer.c
+++ b/generated/beamformer.c
@@ -11,6 +11,7 @@
 #define BeamformerMaxComputeShaderStages   (16)
 #define BeamformerMaxParameterBlocks       (16)
 #define BeamformerMaxRawDataFramesInFlight (3)
+#define BeamformerMaxHadamardElements      (65536)
 
 typedef enum {
 	BeamformerShaderResourceKind_Buffer = 0,
@@ -213,7 +214,6 @@ typedef struct {
 	f32 FocusDepth;
 	f32 TransmitAngle;
 	u32 ReadiGroupCount;
-	u32 ReadiGroup;
 } BeamformerDASBakeParameters;
 
 typedef struct {
@@ -253,7 +253,7 @@ typedef struct {
 	u32 output_size_z;
 	u32 cycle_t;
 	i32 channel_offset;
-	u64 hadamard_buffer;
+	u32 readi_group;
 } BeamformerDASPushConstants;
 
 typedef struct {
@@ -336,11 +336,6 @@ typedef struct {
 } BeamformerFilterParameters;
 
 typedef struct {
-	u32 readi_group_count;
-	u32 readi_group;
-} BeamformerReadiParameters;
-
-typedef struct {
 	m4                        das_voxel_transform;
 	m4                        xdc_transform;
 	v2                        xdc_element_pitch;
@@ -372,7 +367,8 @@ typedef struct {
 typedef struct {
 	BeamformerContrastMode       contrast_mode;
 	BeamformerEmissionParameters emission_parameters;
-	BeamformerReadiParameters    readi_parameters;
+	u32                          readi_group_count;
+	u32                          readi_group;
 } BeamformerExtraParameters;
 
 typedef struct {
@@ -401,7 +397,8 @@ typedef struct {
 	u32                          decimation_rate;
 	BeamformerContrastMode       contrast_mode;
 	BeamformerEmissionParameters emission_parameters;
-	BeamformerReadiParameters    readi_parameters;
+	u32                          readi_group_count;
+	u32                          readi_group;
 } BeamformerParameters;
 
 typedef struct {
@@ -430,7 +427,8 @@ typedef struct {
 	u32                          decimation_rate;
 	BeamformerContrastMode       contrast_mode;
 	BeamformerEmissionParameters emission_parameters;
-	BeamformerReadiParameters    readi_parameters;
+	u32                          readi_group_count;
+	u32                          readi_group;
 	i16                          channel_mapping[BeamformerMaxChannelCount];
 	i16                          sparse_elements[BeamformerMaxEmissionsCount];
 	u8                           transmit_receive_orientations[BeamformerMaxEmissionsCount];
@@ -459,6 +457,7 @@ typedef struct {
 	v2  focal_vectors[BeamformerMaxChannelCount];
 	i16 sparse_elements[BeamformerMaxChannelCount];
 	u16 transmit_receive_orientations[BeamformerMaxChannelCount];
+	f16 hadamard_matrix[BeamformerMaxHadamardElements];
 } BeamformerDASArrayParameters;
 
 typedef union {
@@ -641,7 +640,6 @@ read_only global MetaStructMember *meta_struct_members_by_id[] = {
 		{8,  60, 1, 0},
 		{8,  64, 1, 0},
 		{18, 68, 1, 0},
-		{18, 72, 1, 0},
 	},
 	(MetaStructMember []){
 		{18, 0,  1, 0},
@@ -703,7 +701,6 @@ read_only global str8 *meta_struct_member_names_by_id[] = {
 		str8_comp("FocusDepth"),
 		str8_comp("TransmitAngle"),
 		str8_comp("ReadiGroupCount"),
-		str8_comp("ReadiGroup"),
 	},
 	(str8 []){
 		str8_comp("SizeX"),
@@ -721,7 +718,7 @@ read_only global str8 *meta_struct_member_names_by_id[] = {
 read_only global MetaStructInfo meta_struct_info_by_id[] = {
 	{str8_comp("DecodeBakeParameters"),  11, 44, 0},
 	{str8_comp("FilterBakeParameters"),  12, 48, 0},
-	{str8_comp("DASBakeParameters"),     19, 76, 0},
+	{str8_comp("DASBakeParameters"),     18, 72, 0},
 	{str8_comp("ReshapeBakeParameters"), 9,  36, 0},
 };
 
@@ -824,6 +821,7 @@ read_only global str8 beamformer_shader_global_header_strings[] = {
 	"};\n"
 	"\n"),
 	str8_comp("#define MaxChannelCount (256)\n\n"),
+	str8_comp("#define MaxHadamardElements (65536)\n\n"),
 	str8_comp(""
 	"#define AcquisitionKind_FORCES         0\n"
 	"#define AcquisitionKind_UFORCES        1\n"
@@ -851,9 +849,10 @@ read_only global str8 beamformer_shader_global_header_strings[] = {
 	"\n"),
 	str8_comp(""
 	"struct DASArrayParameters {\n"
-	"  f32vec2  focal_vectors[MaxChannelCount];\n"
-	"  int16_t  sparse_elements[MaxChannelCount];\n"
-	"  uint16_t transmit_receive_orientations[MaxChannelCount];\n"
+	"  f32vec2   focal_vectors[MaxChannelCount];\n"
+	"  int16_t   sparse_elements[MaxChannelCount];\n"
+	"  uint16_t  transmit_receive_orientations[MaxChannelCount];\n"
+	"  float16_t hadamard_matrix[MaxHadamardElements];\n"
 	"};\n"
 	"\n"),
 	str8_comp(""
@@ -873,7 +872,7 @@ read_only global str8 beamformer_shader_global_header_strings[] = {
 	"  uint32_t output_size_z;\n"
 	"  uint32_t cycle_t;\n"
 	"  int32_t  channel_offset;\n"
-	"  uint64_t hadamard_buffer;\n"
+	"  uint32_t readi_group;\n"
 	"};\n"
 	"\n"),
 	str8_comp(""
@@ -949,18 +948,18 @@ read_only global b8 beamformer_shader_primitive_is_vertex[] = {
 read_only global i32 *beamformer_shader_header_vectors[] = {
 	(i32 []){0, 1, 2},
 	(i32 []){3, 4, 5, 6},
-	(i32 []){7, 8, 9, 10, 3, 4, 11, 12, 13},
-	(i32 []){14},
-	0,
+	(i32 []){7, 8, 9, 10, 11, 3, 4, 12, 13, 14},
 	(i32 []){15},
-	(i32 []){16, 17},
-	(i32 []){18},
+	0,
+	(i32 []){16},
+	(i32 []){17, 18},
+	(i32 []){19},
 };
 
 read_only global i32 beamformer_shader_header_vector_lengths[] = {
 	3,
 	4,
-	9,
+	10,
 	1,
 	0,
 	1,

--- a/generated/beamformer.c
+++ b/generated/beamformer.c
@@ -212,6 +212,8 @@ typedef struct {
 	b32 SingleFocus;
 	f32 FocusDepth;
 	f32 TransmitAngle;
+	u32 ReadiGroupCount;
+	u32 ReadiGroup;
 } BeamformerDASBakeParameters;
 
 typedef struct {
@@ -251,6 +253,7 @@ typedef struct {
 	u32 output_size_z;
 	u32 cycle_t;
 	i32 channel_offset;
+	u64 hadamard_buffer;
 } BeamformerDASPushConstants;
 
 typedef struct {
@@ -333,6 +336,11 @@ typedef struct {
 } BeamformerFilterParameters;
 
 typedef struct {
+	u32 readi_group_count;
+	u32 readi_group;
+} BeamformerReadiParameters;
+
+typedef struct {
 	m4                        das_voxel_transform;
 	m4                        xdc_transform;
 	v2                        xdc_element_pitch;
@@ -364,6 +372,7 @@ typedef struct {
 typedef struct {
 	BeamformerContrastMode       contrast_mode;
 	BeamformerEmissionParameters emission_parameters;
+	BeamformerReadiParameters    readi_parameters;
 } BeamformerExtraParameters;
 
 typedef struct {
@@ -392,6 +401,7 @@ typedef struct {
 	u32                          decimation_rate;
 	BeamformerContrastMode       contrast_mode;
 	BeamformerEmissionParameters emission_parameters;
+	BeamformerReadiParameters    readi_parameters;
 } BeamformerParameters;
 
 typedef struct {
@@ -420,6 +430,7 @@ typedef struct {
 	u32                          decimation_rate;
 	BeamformerContrastMode       contrast_mode;
 	BeamformerEmissionParameters emission_parameters;
+	BeamformerReadiParameters    readi_parameters;
 	i16                          channel_mapping[BeamformerMaxChannelCount];
 	i16                          sparse_elements[BeamformerMaxEmissionsCount];
 	u8                           transmit_receive_orientations[BeamformerMaxEmissionsCount];
@@ -629,6 +640,8 @@ read_only global MetaStructMember *meta_struct_members_by_id[] = {
 		{14, 56, 1, 0},
 		{8,  60, 1, 0},
 		{8,  64, 1, 0},
+		{18, 68, 1, 0},
+		{18, 72, 1, 0},
 	},
 	(MetaStructMember []){
 		{18, 0,  1, 0},
@@ -689,6 +702,8 @@ read_only global str8 *meta_struct_member_names_by_id[] = {
 		str8_comp("SingleFocus"),
 		str8_comp("FocusDepth"),
 		str8_comp("TransmitAngle"),
+		str8_comp("ReadiGroupCount"),
+		str8_comp("ReadiGroup"),
 	},
 	(str8 []){
 		str8_comp("SizeX"),
@@ -706,7 +721,7 @@ read_only global str8 *meta_struct_member_names_by_id[] = {
 read_only global MetaStructInfo meta_struct_info_by_id[] = {
 	{str8_comp("DecodeBakeParameters"),  11, 44, 0},
 	{str8_comp("FilterBakeParameters"),  12, 48, 0},
-	{str8_comp("DASBakeParameters"),     17, 68, 0},
+	{str8_comp("DASBakeParameters"),     19, 76, 0},
 	{str8_comp("ReshapeBakeParameters"), 9,  36, 0},
 };
 
@@ -858,6 +873,7 @@ read_only global str8 beamformer_shader_global_header_strings[] = {
 	"  uint32_t output_size_z;\n"
 	"  uint32_t cycle_t;\n"
 	"  int32_t  channel_offset;\n"
+	"  uint64_t hadamard_buffer;\n"
 	"};\n"
 	"\n"),
 	str8_comp(""

--- a/lib/ogl_beamformer_lib.c
+++ b/lib/ogl_beamformer_lib.c
@@ -689,6 +689,18 @@ beamformer_export(BeamformerExportContext export, void *out, i32 timeout_ms)
 	return result;
 }
 
+BEAMFORMER_LIB_EXPORT b32 
+beamformer_get_last_frames(void* out_data, uint64_t out_data_size, uint32_t count)
+{
+	if (!out_data || out_data_size == 0 || count == 0) return 0;
+
+	BeamformerExportContext export = {0};
+	export.kind = BeamformerExportKind_BeamformedData;
+	export.size = out_data_size;
+	export.count = count;
+	return beamformer_export(export, out_data, g_beamformer_library_context.timeout_ms);
+}
+
 b32
 beamformer_beamform_data(BeamformerSimpleParameters *bp, void *data, uint32_t data_size,
                          void *out_data, int32_t timeout_ms)
@@ -716,27 +728,11 @@ beamformer_beamform_data(BeamformerSimpleParameters *bp, void *data, uint32_t da
 		if (result) {
 			result = beamformer_push_data_with_compute(data, data_size, 0, 0);
 			if (result && out_data) {
-				BeamformerExportContext export;
-				export.kind = BeamformerExportKind_BeamformedData;
-				export.size = (u32)output_size;
-				export.count = 1;
-				result = beamformer_export(export, out_data, timeout_ms);
+				result = beamformer_get_last_frames(out_data, output_size, 1);
 			}
 		}
 	}
 	return result;
-}
-
-BEAMFORMER_LIB_EXPORT b32 
-beamformer_get_last_frames(void* out_data, uint32_t memory_size, uint32_t count)
-{
-	if (!out_data || memory_size == 0 || count == 0) return 0;
-
-	BeamformerExportContext export;
-	export.kind = BeamformerExportKind_BeamformedData;
-	export.size = memory_size;
-	export.count = count;
-	return beamformer_export(export, out_data, g_beamformer_library_context.timeout_ms);
 }
 
 BEAMFORMER_LIB_EXPORT b32
@@ -747,7 +743,7 @@ beamformer_compute_timings(BeamformerComputeStatsTable *output, i32 timeout_ms)
 		Arena scratch = beamformer_shared_memory_scratch_arena(g_beamformer_library_context.bp,
 		                                                       g_beamformer_library_context.shared_memory_size);
 		if (lib_error_check((i64)sizeof(*output) <= arena_capacity(&scratch, u8), ExportSpaceOverflow)) {
-			BeamformerExportContext export;
+			BeamformerExportContext export = {0};
 			export.kind = BeamformerExportKind_Stats;
 			export.size = sizeof(*output);
 			export.count = 0;

--- a/lib/ogl_beamformer_lib.c
+++ b/lib/ogl_beamformer_lib.c
@@ -719,11 +719,24 @@ beamformer_beamform_data(BeamformerSimpleParameters *bp, void *data, uint32_t da
 				BeamformerExportContext export;
 				export.kind = BeamformerExportKind_BeamformedData;
 				export.size = (u32)output_size;
+				export.count = 1;
 				result = beamformer_export(export, out_data, timeout_ms);
 			}
 		}
 	}
 	return result;
+}
+
+BEAMFORMER_LIB_EXPORT b32 
+beamformer_get_last_frames(void* out_data, uint32_t memory_size, uint32_t count)
+{
+	if (!out_data || memory_size == 0 || count == 0) return 0;
+
+	BeamformerExportContext export;
+	export.kind = BeamformerExportKind_BeamformedData;
+	export.size = memory_size;
+	export.count = count;
+	return beamformer_export(export, out_data, g_beamformer_library_context.timeout_ms);
 }
 
 BEAMFORMER_LIB_EXPORT b32

--- a/lib/ogl_beamformer_lib.c
+++ b/lib/ogl_beamformer_lib.c
@@ -750,6 +750,7 @@ beamformer_compute_timings(BeamformerComputeStatsTable *output, i32 timeout_ms)
 			BeamformerExportContext export;
 			export.kind = BeamformerExportKind_Stats;
 			export.size = sizeof(*output);
+			export.count = 0;
 			result = beamformer_export(export, output, timeout_ms);
 		}
 	}

--- a/lib/ogl_beamformer_lib_base.h
+++ b/lib/ogl_beamformer_lib_base.h
@@ -85,6 +85,8 @@ BEAMFORMER_LIB_EXPORT uint32_t beamformer_push_data_with_compute(void *data, uin
                                                                  uint32_t image_plane_tag,
                                                                  uint32_t parameter_slot);
 
+BEAMFORMER_LIB_EXPORT uint32_t beamformer_get_last_frames(void* out_data, uint32_t frame_size, uint32_t count);
+
 ///////////////////////////
 // Parameter Configuration
 BEAMFORMER_LIB_EXPORT uint32_t beamformer_reserve_parameter_blocks(uint32_t count);

--- a/lib/ogl_beamformer_lib_base.h
+++ b/lib/ogl_beamformer_lib_base.h
@@ -85,7 +85,22 @@ BEAMFORMER_LIB_EXPORT uint32_t beamformer_push_data_with_compute(void *data, uin
                                                                  uint32_t image_plane_tag,
                                                                  uint32_t parameter_slot);
 
-BEAMFORMER_LIB_EXPORT uint32_t beamformer_get_last_frames(void* out_data, uint32_t frame_size, uint32_t count);
+
+/* Returns the last N beamformed frames, ordered from oldest to newest.
+ * out_data: Preallocated output buffer.
+ * out_data_size: Total output buffer size.
+ * count: Number of frames to return.
+ * 
+ * NOTES:
+ * - Individual frame sizes are rounded up to 64 byte alignment prior to export
+ * 
+ * - Frame size is not guarenteed to be consistent between frames, 
+ *   it is the callers responsibility to know the correct dimensions of each frame.
+ * 
+ * - The buffer will be filled one frame at a time from oldest to newest, 
+ *   if the output buffer is too small the most recent frames will be dropped.
+ */
+BEAMFORMER_LIB_EXPORT uint32_t beamformer_get_last_frames(void* out_data, uint64_t out_data_size, uint32_t count);
 
 ///////////////////////////
 // Parameter Configuration

--- a/shaders/das.glsl
+++ b/shaders/das.glsl
@@ -47,6 +47,10 @@ layout(std430, buffer_reference) buffer IncoherentOutput {
 	f32 x[];
 };
 
+layout(std430, buffer_reference, buffer_reference_align = 64) restrict readonly buffer Hadamard {
+	f16 x[];
+};
+
 #define RX_ORIENTATION(tx_rx) bitfieldExtract((tx_rx), 0, 4)
 #define TX_ORIENTATION(tx_rx) bitfieldExtract((tx_rx), 4, 4)
 
@@ -320,6 +324,51 @@ RESULT_TYPE FORCES(const vec3 xdc_world_point)
 	return result;
 }
 
+RESULT_TYPE READI_FORCES(const vec3 xdc_world_point)
+{
+	RESULT_TYPE result = RESULT_TYPE(0);
+
+	float z_delta_squared     = xdc_world_point.z * xdc_world_point.z;
+	float transmit_y_delta    = xdc_world_point.y - xdc_element_pitch.y * ChannelCount / 2;
+	float transmit_yz_squared = transmit_y_delta * transmit_y_delta + z_delta_squared;
+
+	// NOTE(tkh): The row we use matches the acquisition group, the column is the element group we are beamforming.
+	s32 hadamard_offset = s32(ReadiGroup) * s32(ReadiGroupCount);
+
+	for (f32 chunk_channel = 0; chunk_channel < f32(ChunkChannelCount); chunk_channel += 1.0f) {
+		float rx_channel      = float(channel_offset) + chunk_channel;
+		float receive_x_delta = xdc_world_point.x - rx_channel * xdc_element_pitch.x;
+		float a_arg           = abs(FNumber * receive_x_delta / xdc_world_point.z);
+
+		if (a_arg < 0.5f) {
+			s32 channel_rf_offset  = s32(rf_element_offset) + s32(chunk_channel) * SampleCount * AcquisitionCount;
+			channel_rf_offset     -= s32(InterpolationMode == InterpolationMode_Cubic);
+
+			float receive_index = sample_index(sqrt(receive_x_delta * receive_x_delta + z_delta_squared));
+			float apodization   = apodize(a_arg);
+
+			// NOTE(tkh): Iterating over groups of tx elements, each group is AcquisitionCount sequential elements.
+			// The first element in each group is beamformed using the first acquisition, the second element in each group is beamformed using the second acquisition, etc.
+			for (s32 tx_group = 0; tx_group < s32(ReadiGroupCount); tx_group++) {
+				s32 rf_offset = channel_rf_offset;
+				f16 hadamard_value = Hadamard(hadamard_buffer).x[hadamard_offset + tx_group];
+				float group_apodization = apodization * f32(hadamard_value);
+
+				for (s32 tx_event = 0; tx_event < AcquisitionCount; tx_event++) {
+					s32 tx_element = tx_group * AcquisitionCount + tx_event;
+					float transmit_x_delta = xdc_world_point.x - xdc_element_pitch.x * tx_element;
+					float transmit_index   = sqrt(transmit_yz_squared + transmit_x_delta * transmit_x_delta) * SamplingFrequency / SpeedOfSound;
+
+					SAMPLE_TYPE value = group_apodization * sample_rf(rf_offset, receive_index + transmit_index);
+					result    += RESULT_STORE(value);
+					rf_offset += SampleCount;
+				}
+			}
+		}
+	}
+	return result;
+}
+
 void main()
 {
 	uvec3 out_voxel = gl_GlobalInvocationID;
@@ -337,7 +386,8 @@ void main()
 	case AcquisitionKind_FORCES:
 	case AcquisitionKind_UFORCES:
 	{
-		sum = FORCES(world_point);
+		if(ReadiGroupCount > 1){ sum = READI_FORCES(world_point); }
+		else { sum = FORCES(world_point); }
 	}break;
 	case AcquisitionKind_HERCULES:
 	case AcquisitionKind_UHERCULES:

--- a/shaders/das.glsl
+++ b/shaders/das.glsl
@@ -47,10 +47,6 @@ layout(std430, buffer_reference) buffer IncoherentOutput {
 	f32 x[];
 };
 
-layout(std430, buffer_reference, buffer_reference_align = 64) restrict readonly buffer Hadamard {
-	f16 x[];
-};
-
 #define RX_ORIENTATION(tx_rx) bitfieldExtract((tx_rx), 0, 4)
 #define TX_ORIENTATION(tx_rx) bitfieldExtract((tx_rx), 4, 4)
 
@@ -333,7 +329,7 @@ RESULT_TYPE READI_FORCES(const vec3 xdc_world_point)
 	float transmit_yz_squared = transmit_y_delta * transmit_y_delta + z_delta_squared;
 
 	// NOTE(tkh): The row we use matches the acquisition group, the column is the element group we are beamforming.
-	s32 hadamard_offset = s32(ReadiGroup) * s32(ReadiGroupCount);
+	s32 hadamard_offset = s32(readi_group) * s32(ReadiGroupCount);
 
 	for (f32 chunk_channel = 0; chunk_channel < f32(ChunkChannelCount); chunk_channel += 1.0f) {
 		float rx_channel      = float(channel_offset) + chunk_channel;
@@ -351,7 +347,7 @@ RESULT_TYPE READI_FORCES(const vec3 xdc_world_point)
 			// The first element in each group is beamformed using the first acquisition, the second element in each group is beamformed using the second acquisition, etc.
 			for (s32 tx_group = 0; tx_group < s32(ReadiGroupCount); tx_group++) {
 				s32 rf_offset = channel_rf_offset;
-				f16 hadamard_value = Hadamard(hadamard_buffer).x[hadamard_offset + tx_group];
+				f16 hadamard_value = ArrayParameters(array_parameters).data.hadamard_matrix[hadamard_offset + tx_group];
 				float group_apodization = apodization * f32(hadamard_value);
 
 				for (s32 tx_event = 0; tx_event < AcquisitionCount; tx_event++) {


### PR DESCRIPTION
Added basic READI beamforming support. It is currently set up so that each group has its own parameters block and is beamformed independently; thus, the data from each group must be separated and uploaded individually. Variable names are recommendations and can be modified. 

The `ExtraParameters` BP struct now includes a `ReadiParameters` struct, which provides `readi_group_count` and `readi_group.`

`readi_group_count` indicates the number of READI groups the transmits are separated into, while `readi_group` indicates which group is currently being beamformed. When using READI, `acquisition_count` should be set to the number of transmits in the group (`readi_group_count * acquisition_count = 128` for a FORCES 128 sequence). 

When `readi_group_count` > 1 READI is enabled in the DAS shader and the second Hadamard matrix of rank `readi_group_size` is generated. 

For a basic explanation of the READI_FORCES DAS shader: If a READI group has 32/128 total acquisitions, then each of the 32 signals corresponds to 4 transmitting elements. Acquisition 1 corresponds with elements 1, 33, 65, 93; Acquisition 2 corresponds to elements 2, 34, 66, 64, etc. We iterate over them from left to right using the same delay calculations, but the signal we sample is determined by `tx_element % acquisition_count`. To complete the decoding we multiply each sample by a term in the 4x4 Hadamard matrix, where the row corresponds to which group of events we are beamforming and the column corresponds to which of the 4 elements in the signal we are beamforming for. (Ex when beamforming READI group one, elements 33-64 will have their samples multiplied by H[0][1]).

Additionally, the buffer export API has been updated to allow multi-frame exports; BeamformerExportContext now includes a `count` field indicating how many frames to export, rather than exporting only the most recent frame. This can handle returning frames of multiple sizes, it is assumed the caller will correctly know how to reshape the data. It exports each frame one at a time, so it should handle all wraparound cases with the ring buffer (though this hasn't been thoroughly tested.  

We can discuss adding support for uploading a full FORCES dataset once, then calling READI, however that will require a swizzle from [Sample, Acquisition(1..128), Channel] to [SampleCount, Acquisition(1..GroupSize), ChannelCount, ReadiGroup(1..GroupCount)].

To validate this, take a FORCES dataset, break it into groups as above, then call BeamformSimple on each group and sum the resulting images (don't average). The sum should be identical to the output of a standard FORCES beamform within numeric precision. 
